### PR TITLE
DNSレコード更新前にログ出力を追加し、型定義を修正した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lycolia/value-domain-dns-cert-register",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lycolia/value-domain-dns-cert-register",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lycolia/value-domain-dns-cert-register",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Automatically add dns certificates for value-domain using on certbot manual mode",
   "keywords": [
     "automation",

--- a/src/libs/ValueDomainClient/index.ts
+++ b/src/libs/ValueDomainClient/index.ts
@@ -3,7 +3,7 @@ import { Logger } from '../Logger';
 import { VdDnsAPIResponse, VdDnsUpdateRequest } from '../../types/VdDnsAPI';
 import {
   GetDnsRecordsError,
-  UpdateDnsRecordsError,
+  UpdateDnsRecordsError
 } from '../../resources/ErrorDefines';
 import { reThrow } from '../ReThrow';
 
@@ -24,8 +24,8 @@ export const requestGetDnsConf = async (
       `${baseUrl}/domains/${rootDomain}/dns`,
       {
         headers: {
-          Authorization: `Bearer ${apiToken}`,
-        },
+          Authorization: `Bearer ${apiToken}`
+        }
       }
     );
 
@@ -41,14 +41,16 @@ export const requestUpdateDnsConf = async (
   apiToken: string,
   updateRecords: VdDnsUpdateRequest
 ) => {
+  Logger.info('Request update DNS records', JSON.stringify(updateRecords));
+
   try {
     const { data } = await axios.put(
       `${baseUrl}/domains/${rootDomain}/dns`,
       updateRecords,
       {
         headers: {
-          Authorization: `Bearer ${apiToken}`,
-        },
+          Authorization: `Bearer ${apiToken}`
+        }
       }
     );
 

--- a/src/types/VdDnsAPI.ts
+++ b/src/types/VdDnsAPI.ts
@@ -6,8 +6,7 @@ export type VdDnsAPIResponse = {
     ns_type: string;
     /** DNSレコード文字列、コメントは除去されてくる */
     records: string;
-    /** "60"とかの数字文字列 */
-    ttl: string;
+    ttl: number;
   };
   /** "20190502412345678" */
   request_id: string;
@@ -19,6 +18,6 @@ export type VdDnsUpdateRequest = {
   ns_type: string;
   /** DNSレコード文字列 */
   records: string;
-  /** "60"とかの数字文字列 */
-  ttl: string;
+  /** TODO: 今のところ送っても機能してない模様 */
+  ttl: number;
 };


### PR DESCRIPTION
- DNSレコード更新前にAPIに投げるリクエスト内容をログに出すようにした
- ttlの型定義が現実に即していないのを修正
  - [DNS設定の一覧取得](https://www.value-domain.com/api/doc/domain/#tag/DNS)のResponse samplesでは文字列で書かれているが、実際は数値が返ってくる。Responsesの欄にはIntegerとあるのでtypoだと思うが、この表記を鵜呑みにしていた。
   ![image](https://github.com/user-attachments/assets/543d608c-ce14-4adf-9b75-5ae9639ec704)
